### PR TITLE
Basic map generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,5 @@ bevy_egui = "0.11"
 anyhow = "1.0"
 bevy_kira_audio = "0.8"
 heron = { version = "2.0.1", features = ["2d", "enhanced-determinism"] }
+bevy-inspector-egui = "0.8"
+rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,15 @@ bevy = { version = "0.6", features = [
 ] }
 bevy_ecs_tilemap = "0.5"
 bevy_egui = "0.11"
+<<<<<<< HEAD
 anyhow = "1.0"
 bevy_kira_audio = "0.8"
 heron = { version = "2.0.1", features = ["2d", "enhanced-determinism"] }
 bevy-inspector-egui = "0.8"
 rand = "0.8"
+=======
+bevy_rapier2d = "0.12"
+anyhow = "1.0"
+bevy-inspector-egui = "0.8"
+rand = "0.8"
+>>>>>>> 8b7a065 (start room gen)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,15 +32,8 @@ bevy = { version = "0.6", features = [
 ] }
 bevy_ecs_tilemap = "0.5"
 bevy_egui = "0.11"
-<<<<<<< HEAD
 anyhow = "1.0"
 bevy_kira_audio = "0.8"
 heron = { version = "2.0.1", features = ["2d", "enhanced-determinism"] }
 bevy-inspector-egui = "0.8"
 rand = "0.8"
-=======
-bevy_rapier2d = "0.12"
-anyhow = "1.0"
-bevy-inspector-egui = "0.8"
-rand = "0.8"
->>>>>>> 8b7a065 (start room gen)

--- a/src/levels/mod.rs
+++ b/src/levels/mod.rs
@@ -36,14 +36,13 @@ fn level_setup(mut commands: Commands, asset_server: Res<AssetServer>, mut map_q
     let mut outside_tile = TileBundle::default();
     outside_tile.tile.texture_index = 9;
     let mut floor_tile = TileBundle::default();
-    floor_tile.tile.texture_index = 0;
+    floor_tile.tile.texture_index = 4;
 
+    layer_builder.fill(TilePos(1, 1), TilePos(10, 10), floor_tile.clone());
     layer_builder.for_each_tiles_mut(|tile_entity, tile_data| {
-        *tile_data = Some(if rand::random() {
-            outside_tile.clone()
-        } else {
-            floor_tile.clone()
-        });
+        if tile_data.is_none() {
+            *tile_data = Some(outside_tile.clone());
+        }
 
         if tile_entity.is_none() {
             *tile_entity = Some(commands.spawn().id());

--- a/src/levels/mod.rs
+++ b/src/levels/mod.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{input::mouse::MouseWheel, prelude::*};
 use bevy_ecs_tilemap::prelude::*;
 
 use crate::GameState;
@@ -9,7 +9,8 @@ impl Plugin for SinglePlayerScene {
     fn build(&self, app: &mut App) {
         app.add_plugin(TilemapPlugin)
             .add_system(crate::utils::set_texture_filters_to_nearest)
-            .add_system_set(SystemSet::on_enter(GameState::Playing).with_system(level_setup));
+            .add_system_set(SystemSet::on_enter(GameState::Playing).with_system(level_setup))
+            .add_system_set(SystemSet::on_update(GameState::Playing).with_system(zoom_update));
     }
 }
 
@@ -32,9 +33,22 @@ fn level_setup(mut commands: Commands, asset_server: Res<AssetServer>, mut map_q
         0u16,
     );
 
-    let mut tile = TileBundle::default();
-    tile.tile.texture_index = 9;
-    layer_builder.set_all(tile);
+    let mut outside_tile = TileBundle::default();
+    outside_tile.tile.texture_index = 9;
+    let mut floor_tile = TileBundle::default();
+    floor_tile.tile.texture_index = 0;
+
+    layer_builder.for_each_tiles_mut(|tile_entity, tile_data| {
+        *tile_data = Some(if rand::random() {
+            outside_tile.clone()
+        } else {
+            floor_tile.clone()
+        });
+
+        if tile_entity.is_none() {
+            *tile_entity = Some(commands.spawn().id());
+        }
+    });
 
     let layer_entity = map_query.build_layer(&mut commands, layer_builder, texture_handle);
 
@@ -43,5 +57,34 @@ fn level_setup(mut commands: Commands, asset_server: Res<AssetServer>, mut map_q
     commands
         .entity(map_entity)
         .insert(map)
+        .insert(Transform::from_xyz(-128.0, -128.0, 0.0))
         .insert(GlobalTransform::default());
+}
+
+fn zoom_update(
+    mut scroll: EventReader<MouseWheel>,
+    mut query: Query<&mut OrthographicProjection, With<Camera>>,
+) {
+    for mut projection in query.iter_mut() {
+        for ev in scroll.iter() {
+            let mut log_scale = projection.scale.ln();
+            log_scale += ev.y;
+            projection.scale = log_scale.exp();
+        }
+    }
+}
+
+// fn list_tiles(query: Query<)
+
+fn fill_layer<T: TileBundleTrait + Clone>(
+    lb: &mut LayerBuilder<T>,
+    start: TilePos,
+    end: TilePos,
+    tile: T,
+) {
+    for x in start.0..end.0 {
+        for y in start.1..end.1 {
+            lb.set_tile(TilePos(x, y), tile.clone()).unwrap();
+        }
+    }
 }

--- a/src/levels/mod.rs
+++ b/src/levels/mod.rs
@@ -44,12 +44,12 @@ fn level_setup(mut commands: Commands, asset_server: Res<AssetServer>, mut map_q
         let mut rng = rand::thread_rng();
         let size_distrib = Uniform::new(5, 15);
         let settings = layer_builder.settings.clone();
-        for _ in 0..30 {
+        for _ in 0..Uniform::new(10, 37).sample(&mut rng) {
             let size_x = size_distrib.sample(&mut rng);
             let size_y = size_distrib.sample(&mut rng);
-            let x = Uniform::new(1, settings.map_size.0 * settings.chunk_size.0 - 1 - size_x)
+            let x = Uniform::new(1, settings.map_size.0 * settings.chunk_size.0 - size_x)
                 .sample(&mut rng);
-            let y = Uniform::new(1, settings.map_size.1 * settings.chunk_size.1 - 1 - size_y)
+            let y = Uniform::new(1, settings.map_size.1 * settings.chunk_size.1 - size_y)
                 .sample(&mut rng);
             layer_builder.fill(
                 TilePos(x, y),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use bevy_kira_audio::AudioPlugin;
 use heron::prelude::*;
 use inputs::GameInputPlugin;
 use resources::audio_channels::AudioChannels;
+use bevy_inspector_egui::WorldInspectorPlugin;
 
 mod inputs;
 mod levels;
@@ -39,6 +40,7 @@ fn main() {
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(EguiPlugin)
         .add_plugin(AudioPlugin)
+        .add_plugin(WorldInspectorPlugin::new())
         .add_plugin(menus::MainMenuScene)
         .add_plugin(levels::SinglePlayerScene)
         .add_state(GameState::MainMenu)

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,13 @@ use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin};
 use bevy::prelude::*;
 use bevy::window::WindowMode;
 use bevy_egui::EguiPlugin;
+<<<<<<< HEAD
 use bevy_kira_audio::AudioPlugin;
 use heron::prelude::*;
 use inputs::GameInputPlugin;
 use resources::audio_channels::AudioChannels;
+=======
+>>>>>>> 8b7a065 (start room gen)
 use bevy_inspector_egui::WorldInspectorPlugin;
 
 mod inputs;
@@ -39,7 +42,10 @@ fn main() {
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(EguiPlugin)
+<<<<<<< HEAD
         .add_plugin(AudioPlugin)
+=======
+>>>>>>> 8b7a065 (start room gen)
         .add_plugin(WorldInspectorPlugin::new())
         .add_plugin(menus::MainMenuScene)
         .add_plugin(levels::SinglePlayerScene)

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,14 +5,11 @@ use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin};
 use bevy::prelude::*;
 use bevy::window::WindowMode;
 use bevy_egui::EguiPlugin;
-<<<<<<< HEAD
+use bevy_inspector_egui::WorldInspectorPlugin;
 use bevy_kira_audio::AudioPlugin;
 use heron::prelude::*;
 use inputs::GameInputPlugin;
 use resources::audio_channels::AudioChannels;
-=======
->>>>>>> 8b7a065 (start room gen)
-use bevy_inspector_egui::WorldInspectorPlugin;
 
 mod inputs;
 mod levels;
@@ -42,10 +39,7 @@ fn main() {
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(EguiPlugin)
-<<<<<<< HEAD
         .add_plugin(AudioPlugin)
-=======
->>>>>>> 8b7a065 (start room gen)
         .add_plugin(WorldInspectorPlugin::new())
         .add_plugin(menus::MainMenuScene)
         .add_plugin(levels::SinglePlayerScene)


### PR DESCRIPTION
- Make map generate using a cellular automata technique

In the future, we should consider different map generation types, such as standard roguelike room generation. Also, `bevy_ecs_tilemap` can import maps from both [LDtk](https://ldtk.io/) and [tiled](https://www.mapeditor.org/), which I think we should consider supporting.